### PR TITLE
fix(#390): resolve API throttling for DescribePermissionSet calls

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -31,4 +31,4 @@ const (
 
 const DEFAULT_FILENAME string = "aws.config"
 
-const DEFAULT_TIMEOUT time.Duration = 2 * time.Minute
+const DEFAULT_TIMEOUT time.Duration = 5 * time.Minute

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -249,4 +249,3 @@ func TestLogFormatFlagRegistered(t *testing.T) {
 		t.Errorf("Expected --%s default to be 'plain', got %q", FlagLogFormat, flag.DefValue)
 	}
 }
-

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -25,19 +25,21 @@ func init() {
 }
 
 func loadAWSConfig(ctx context.Context) (aws.Config, error) {
-	if profile != "" {
-		slog.Info("Loading AWS config with profile", "profile", profile)
-		cfg, err := config.LoadDefaultConfig(ctx,
-			config.WithRegion(ssoRegion),
-			config.WithSharedConfigProfile(profile))
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("failed to load AWS configuration with profile %s: %w", profile, err)
-		}
-		return cfg, nil
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(ssoRegion),
+		config.WithRetryMaxAttempts(10),
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(ssoRegion))
+	if profile != "" {
+		slog.Info("Loading AWS config with profile", "profile", profile)
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
+		if profile != "" {
+			return aws.Config{}, fmt.Errorf("failed to load AWS configuration with profile %s: %w", profile, err)
+		}
 		return aws.Config{}, fmt.Errorf("failed to load AWS configuration: %w", err)
 	}
 	return cfg, nil

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -59,4 +59,3 @@ type mockOrganizationsClient struct {
 func (m *mockOrganizationsClient) ListAccounts(ctx context.Context, params *organizations.ListAccountsInput, optFns ...func(*organizations.Options)) (*organizations.ListAccountsOutput, error) {
 	return m.ListAccountsFunc(ctx, params, optFns...)
 }
-

--- a/ssoadmin.go
+++ b/ssoadmin.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 )
+
+const describePermissionSetConcurrency = 5
 
 // Define interface for the SSO Admin client to make testing easier
 type SSOAdminClient interface {
@@ -86,25 +89,7 @@ func PermissionSets(ctx context.Context, client SSOAdminClient, instanceArn stri
 		token = resp.NextToken
 	}
 
-	// Retrieve detailed information for each permission set.
-	for _, arn := range permissionSetArns {
-		params := &ssoadmin.DescribePermissionSetInput{
-			InstanceArn:      aws.String(instanceArn),
-			PermissionSetArn: aws.String(arn),
-		}
-		resp, err := client.DescribePermissionSet(ctx, params)
-		if err != nil {
-			return permissionSets, fmt.Errorf("failed to describe permission set %s: %w", arn, err)
-		}
-
-		if resp.PermissionSet == nil {
-			return permissionSets, fmt.Errorf("nil permission set returned for ARN %s", arn)
-		}
-
-		permissionSets = append(permissionSets, *resp.PermissionSet)
-	}
-
-	return permissionSets, nil
+	return describePermissionSetsConcurrently(ctx, client, instanceArn, permissionSetArns)
 }
 
 // AllPermissionSets retrieves all permission sets defined in an SSO instance.
@@ -138,21 +123,55 @@ func AllPermissionSets(ctx context.Context, client SSOAdminClient, instanceArn s
 		token = resp.NextToken
 	}
 
-	var permissionSets []types.PermissionSet
-	for _, arn := range arns {
-		resp, err := client.DescribePermissionSet(ctx, &ssoadmin.DescribePermissionSetInput{
-			InstanceArn:      aws.String(instanceArn),
-			PermissionSetArn: aws.String(arn),
-		})
-		if err != nil {
-			return permissionSets, fmt.Errorf("failed to describe permission set %s: %w", arn, err)
-		}
+	return describePermissionSetsConcurrently(ctx, client, instanceArn, arns)
+}
 
-		if resp.PermissionSet == nil {
-			return permissionSets, fmt.Errorf("nil permission set returned for ARN %s", arn)
-		}
+type describeResult struct {
+	index int
+	ps    types.PermissionSet
+	err   error
+}
 
-		permissionSets = append(permissionSets, *resp.PermissionSet)
+func describePermissionSetsConcurrently(ctx context.Context, client SSOAdminClient, instanceArn string, arns []string) ([]types.PermissionSet, error) {
+	if len(arns) == 0 {
+		return []types.PermissionSet{}, nil
+	}
+
+	results := make([]describeResult, len(arns))
+	sem := make(chan struct{}, describePermissionSetConcurrency)
+	var wg sync.WaitGroup
+
+	for i, arn := range arns {
+		wg.Add(1)
+		go func(idx int, permSetArn string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			resp, err := client.DescribePermissionSet(ctx, &ssoadmin.DescribePermissionSetInput{
+				InstanceArn:      aws.String(instanceArn),
+				PermissionSetArn: aws.String(permSetArn),
+			})
+			if err != nil {
+				results[idx] = describeResult{index: idx, err: fmt.Errorf("failed to describe permission set %s: %w", permSetArn, err)}
+				return
+			}
+			if resp.PermissionSet == nil {
+				results[idx] = describeResult{index: idx, err: fmt.Errorf("nil permission set returned for ARN %s", permSetArn)}
+				return
+			}
+			results[idx] = describeResult{index: idx, ps: *resp.PermissionSet}
+		}(i, arn)
+	}
+
+	wg.Wait()
+
+	permissionSets := make([]types.PermissionSet, 0, len(arns))
+	for _, r := range results {
+		if r.err != nil {
+			return permissionSets, r.err
+		}
+		permissionSets = append(permissionSets, r.ps)
 	}
 
 	return permissionSets, nil


### PR DESCRIPTION
## Summary

- Increase AWS SDK retry max attempts from 3 (default) to 10, giving the SDK's exponential backoff more room to handle `ThrottlingException` from the SSO Admin API
- Add bounded concurrency (5 workers) for `DescribePermissionSet` calls, replacing the sequential loop that made 700+ serial API calls across 18 accounts
- Increase default command timeout from 2 to 5 minutes to accommodate retry backoff at scale

Closes #390

## Test plan

- [x] `task build` passes
- [x] `task test` passes -- all existing tests pass with the concurrent implementation
- [x] `task fmt` passes
- [x] Verify in CI with `task check` (gosec, govulncheck)
- [x] Manually test against an AWS org with 15+ accounts to confirm no throttling errors

Generated with [Claude Code](https://claude.com/claude-code)
